### PR TITLE
docs: fix messagebirdpubsub general desc

### DIFF
--- a/functions/sendMessagesWithMessageBird/function.config.json
+++ b/functions/sendMessagesWithMessageBird/function.config.json
@@ -1,6 +1,6 @@
 {
     "name": "sendMessagesWithMessageBird",
-    "description": "Send omnichannel messages with MessageBird.",
+    "description": "Send messages with the MessageBird API by emitting a Pub/Sub.",
     "tags": [
         "transactional",
         "sms",


### PR DESCRIPTION
I had to change this in order to differentiate it from the other MessageBird function. Both functions had the same general description.